### PR TITLE
Add property in config to toggle availability

### DIFF
--- a/Attributes/FeatureToggleAttribute.cs
+++ b/Attributes/FeatureToggleAttribute.cs
@@ -1,14 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using StockportGovUK.AspNetCore.Availability.Managers;
 

--- a/Attributes/OperationalToggleAttribute.cs
+++ b/Attributes/OperationalToggleAttribute.cs
@@ -1,14 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.DependencyInjection;
 using StockportGovUK.AspNetCore.Availability.Managers;
 

--- a/Middleware/Availability.cs
+++ b/Middleware/Availability.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Net;
 using System.Threading.Tasks;
 using StockportGovUK.AspNetCore.Availability.Managers;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 
 namespace StockportGovUK.AspNetCore.Availability.Middleware
 {
@@ -23,6 +20,12 @@ namespace StockportGovUK.AspNetCore.Availability.Middleware
             if (context.Request != null)
             {
                 var availabilityConfiguration = _availabilityManager.AvailabilityConfiguration;
+
+                if (!availabilityConfiguration.Enabled)
+                {
+                    await _next.Invoke(context);
+                }
+
                 var appEnabled = await _availabilityManager.IsApplicationEnabled();
 
                 if (!appEnabled && !availabilityConfiguration.IsAccessibleAddress(context.Request))

--- a/Models/AvailabilityConfiguration.cs
+++ b/Models/AvailabilityConfiguration.cs
@@ -11,6 +11,7 @@ namespace StockportGovUK.AspNetCore.Availability.Models
         public bool AllowSwagger { get; set; }
         public string Environment { get; set; }
         public string Key { get; set; }
+        public bool Enabled { get; set; } = true;
 
         public string GetErrorUrl(HttpContext httpContext)
         {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Availability cofiguration should be added to appSettings as below. Note that Key
       "/swagger/index.html"
     ],
     "Environment": "int",
-    "AllowSwagger": true
+    "AllowSwagger": true,
+    "Enabled": true
   }
 ```
 

--- a/StockportGovUK.AspNetCore.Availability.csproj
+++ b/StockportGovUK.AspNetCore.Availability.csproj
@@ -4,7 +4,7 @@
     <PackageId>StockportGovUK.AspNetCore.Availability</PackageId>
     <Title>A package that simplified access to Stockport Availability/Feature toggling services</Title>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <Authors>Colin Lees, Jon Chiles, Jon Hadley</Authors>
     <Company>Stockport Council</Company>
   </PropertyGroup>


### PR DESCRIPTION
Add "Enabled" into the configuration item to allow users to toggle availability registration in different environments.

Enabled defaults to true if not set and the Availability calls will all return true if availability integration is not enabled.